### PR TITLE
[enh] Enable app deployment via Git

### DIFF
--- a/build/server/lib/controller.js
+++ b/build/server/lib/controller.js
@@ -192,7 +192,7 @@ module.exports.install = function(connection, manifest, callback) {
   var app;
   app = new App(manifest);
   app = app.app;
-  if ((drones[app.name] != null) || fs.existsSync(app.dir)) {
+  if (drones[app.name] != null) {
     log.info(app.name + ":already installed");
     log.info(app.name + ":start application");
     return startApp(app, callback);

--- a/build/server/lib/git.js
+++ b/build/server/lib/git.js
@@ -38,10 +38,11 @@ onWrongGitUrl = function(app, done) {
  */
 
 module.exports.init = function(app, callback) {
-  var match, url;
+  var url;
   url = app.repository.url;
-  match = url.match(/\/([\w\-_\.]+)\.git$/);
-  if (!match) {
+  if (url.match(/^\/usr\/local\/cozy/)) {
+    return callback(null);
+  } else if (!url.match(/\/([\w\-_\.]+)\.git$/)) {
     return onWrongGitUrl(app, callback);
   } else {
     return exec('git --version', function(err, stdout, stderr) {

--- a/server/lib/controller.coffee
+++ b/server/lib/controller.coffee
@@ -160,7 +160,7 @@ module.exports.install = (connection, manifest, callback) ->
     app = new App manifest
     app = app.app
     # Check if app exists
-    if drones[app.name]? or fs.existsSync(app.dir)
+    if drones[app.name]?
         log.info "#{app.name}:already installed"
         log.info "#{app.name}:start application"
         # Start application

--- a/server/lib/git.coffee
+++ b/server/lib/git.coffee
@@ -24,9 +24,10 @@ onWrongGitUrl = (app, done) ->
 module.exports.init = (app, callback) ->
     url = app.repository.url
 
-    # Detects if a string is a valid Git URL
-    match = url.match /\/([\w\-_\.]+)\.git$/
-    unless match
+    # Detects if the repository has already been checked out
+    if url.match /^\/usr\/local\/cozy/
+        callback null
+    else if not url.match /\/([\w\-_\.]+)\.git$/
         # URL isn't a Git url, removes the app's directory
         onWrongGitUrl app, callback
     else


### PR DESCRIPTION
## Idea

Being able to `git push` to the proxy and deploy an app this way.

```
$ git remote add cozy https://mycozy.cozycloud.cc/repo/myapp
$ git push cozy master
Username for 'https://mycozy.cozycloud.cc': 
Password for 'https://my@email.org@mycozy.cozycloud.cc':
remote: Counting objects: 75, done.
remote: Compressing objects: 100% (53/53), done.
remote: Total 62 (delta 27), reused 44 (delta 9)
remote: 
remote: info - Deploying 'myapp'
remote: info - Application 'myapp' has been deployed
remote:
Unpacking objects: 100% (62/62), done.
To https://mycozy.cozycloud.cc/repo/myapp
* [new branch]      master     -> cozy/master
```

## Details for cozy-controller

The controller is modified to allow an app to be installed even if the repository has been checked out already, and allow a local git repository as the Git URL.

To merge along with:
* https://github.com/cozy/cozy-home/pull/343
* https://github.com/cozy/cozy-monitor/pull/75
* https://github.com/cozy/cozy-proxy/pull/118

**It lacks of test for now, please keep this PR open**