### PR TITLE
Allow to start a javascript application

### DIFF
--- a/server/controllers/disk.coffee
+++ b/server/controllers/disk.coffee
@@ -115,7 +115,7 @@ module.exports.info = (req, res, next) ->
         return data or defaultData
 
     getCouchStoragePlace (err, dir) ->
-        exec "df -H #{dir}", (err, resp) ->
+        exec "df -h #{dir}", (err, resp) ->
             if err
                 res.send 500, err
             else

--- a/server/lib/app.coffee
+++ b/server/lib/app.coffee
@@ -10,12 +10,14 @@ class exports.App
     constructor: (@app) ->
         homeDir = config('dir_app_bin')
         logDir = config('dir_app_log')
+        folderDir = config('dir_app_data')
 
         @app.dir = path.join(homeDir, @app.name)
         @app.user = 'cozy-' + @app.name
         match = @app.repository.url.match(/\/([\w\-_\.]+)\.git$/)
         @app.logFile = path.join(logDir, "/#{@app.name}.log")
         @app.errFile = path.join(logDir, "/#{@app.name}-err.log")
+        @app.folder = path.join folderDir, @app.name
 
         ## Find server
         # Priority:

--- a/server/lib/app.coffee
+++ b/server/lib/app.coffee
@@ -34,6 +34,12 @@ class exports.App
                 @app.server = start[start.length - 1]
             else if fs.existsSync path.join(@app.dir, 'build', 'server.js')
                 @app.server = 'build/server.js'
-            else
+            else if fs.existsSync path.join(@app.dir, 'server.js')
+                @app.server = 'server.js'
+            else if fs.existsSync path.join(@app.dir, 'server.coffee')
                 @app.server = 'server.coffee'
-        @app.startScript = path.join(@app.dir, @app.server)
+            else
+                log.error "Unable to find a start script"
+
+        if @app.server?
+            @app.startScript = path.join(@app.dir, @app.server)

--- a/server/lib/spawner.coffee
+++ b/server/lib/spawner.coffee
@@ -28,6 +28,7 @@ module.exports.start = (app, callback) ->
         USERNAME: app.user
         HOME: app.dir
         NODE_ENV: process.env.NODE_ENV
+        APPLICATION_PERSISTENT_DIRECTORY: app.folder
 
     if process.env.DB_NAME?
         env.DB_NAME = process.env.DB_NAME


### PR DESCRIPTION
When there's no `start` script in `package.json`, the controller try to start a `server.coffee` file. It should also check if a `server.js` file exists.