### PR TITLE
Write error in usual logs file, not only in errors file

### DIFF
--- a/server/lib/spawner.coffee
+++ b/server/lib/spawner.coffee
@@ -188,10 +188,14 @@ module.exports.start = (app, callback) ->
                 appliProcess.removeListener 'message', onPort
                 clearTimeout timeout
 
+        # When an error occured, information is both append to the log file
+        # (debugging purpose) and to the error file (to see easily if an error
+        # occured).
         onStderr = (err) ->
             err = err.toString()
-            fs.appendFile app.errFile, err, (err) ->
-                console.log err if err?
+            fs.appendFile app.logFile, err, (err) ->
+                fs.appendFile app.errFile, err, (err) ->
+                    console.log err if err?
 
 
         # Start application process

--- a/server/lib/spawner.coffee
+++ b/server/lib/spawner.coffee
@@ -194,6 +194,7 @@ module.exports.start = (app, callback) ->
         onStderr = (err) ->
             err = err.toString()
             fs.appendFile app.logFile, err, (err) ->
+                console.log err if err?
                 fs.appendFile app.errFile, err, (err) ->
                     console.log err if err?
 


### PR DESCRIPTION
I know it's not a good practice but the log provided to the user is the one from the standard output. Adding two log files to display would make things confused. Plus, errors written in the error files lack of context and are harder to debug.