### PR TITLE
Add syslog support

### DIFF
--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -1,0 +1,19 @@
+ENV variables
+=============
+
+Cozy-Controller uses some env variables:
+
+- `HOST` and `PORT` to set on which interface and port cozy-controller listen
+- `NODE_ENV` to set the environment
+  - development is used when hacking (some security checks are disabled)
+  - test is used for running unit tests
+  - production is used when you care about the data
+- `COUCH_HOST` and `COUCH_PORT` are used if CouchDB is not listening on
+  localhost:5984
+- `COUCH_LOCAL_CONFIG` can indicate the config file for CouchDB if it's not in
+  the default place (it's used to compute disk space occupied by CouchDB)
+- `DB_NAME` is the name of the database (`cozy` by default)
+- `BIND_IP_PROXY` can be used is you want the proxy to listen on somethinh
+  else than localhost
+- `USE_SYSLOG`, `SYSLOG_HOST` and `SYSLOG_PORT` if you prefer to use syslog
+  over simple log files in `/usr/local/var/log/cozy`.

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -13,7 +13,7 @@ Cozy-Controller uses some env variables:
 - `COUCH_LOCAL_CONFIG` can indicate the config file for CouchDB if it's not in
   the default place (it's used to compute disk space occupied by CouchDB)
 - `DB_NAME` is the name of the database (`cozy` by default)
-- `BIND_IP_PROXY` can be used is you want the proxy to listen on somethinh
+- `BIND_IP_PROXY` can be used is you want the proxy to listen on something
   else than localhost
 - `USE_SYSLOG`, `SYSLOG_HOST` and `SYSLOG_PORT` if you prefer to use syslog
   over simple log files in `/usr/local/var/log/cozy`.

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "coffee-script": "latest",
     "coffee-coverage": "0.4.2",
     "coffeelint": "1.14.2",
-    "mocha": "1.17.1",
-    "should": "3.1.2"
+    "mocha": "1.17.1"
   },
   "bin": {
     "cozy-controller": "./bin/cozy-controller"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "personal"
   ],
   "dependencies": {
+    "ain2": "1.5.3",
     "americano": "0.4.2",
     "americano-cozy": "0.2.11",
     "async": "1.5.1",

--- a/server/lib/controller.coffee
+++ b/server/lib/controller.coffee
@@ -101,10 +101,6 @@ stopApp = (name, callback) ->
     monitor.once 'exit', onStop
     monitor.once 'error', onErr
     try
-        # Close fd for logs files
-        fs.closeSync running[name].fd[0]
-        fs.closeSync running[name].fd[1]
-    try
         delete running[name]
         #callback null, name
         monitor.stop()

--- a/server/lib/spawner.coffee
+++ b/server/lib/spawner.coffee
@@ -191,7 +191,7 @@ setupLogging = (app, foreverOptions) ->
 module.exports.start = (app, callback) ->
     result = {}
     env = prepareEnv app, env
-    foreverOptions = prepareForeverOptions app
+    foreverOptions = prepareForeverOptions app, env
     logging = setupLogging app, foreverOptions
 
     findStartScript app, (err, isCoffee, foreverArgs) ->
@@ -227,7 +227,7 @@ module.exports.start = (app, callback) ->
                     respond new Error "#{app.name} CANT START"
                 else
                     log.error "#{app.name} HAS FAILED TOO MUCH"
-                    setTimeout (-> monitor.exit 1), 1
+                    setTimeout monitor.stop, 1
 
             onError = (err) ->
                 respond err.toString()

--- a/server/lib/spawner.coffee
+++ b/server/lib/spawner.coffee
@@ -120,20 +120,18 @@ findStartScript = (app, callback) ->
 
 # Delete previous backups and move logs to backups
 rotateLogFiles = (app) ->
-    if fs.existsSync(app.logFile)
+    if fs.existsSync app.logFile
         # If a logFile exists, create a backup
-        app.backup = app.logFile + "-backup"
+        app.backup = "#{app.logFile}-backup"
 
         # delete previous backup
-        if fs.existsSync(app.backup)
-            fs.unlinkSync app.backup
+        fs.unlinkSync app.backup if fs.existsSync app.backup
         fs.renameSync app.logFile, app.backup
 
-    if fs.existsSync(app.errFile)
+    if fs.existsSync app.errFile
         # If a errFile exists, create a backup
-        app.backupErr = app.errFile + "-backup"
-        if fs.existsSync(app.backupErr)
-            fs.unlinkSync app.backupErr
+        app.backupErr = "#{app.errFile}-backup"
+        fs.unlinkSync app.backupErr if fs.existsSync app.backupErr
         fs.renameSync app.errFile, app.backupErr
 
 
@@ -167,9 +165,11 @@ setupSyslog = (app, foreverOptions) ->
             logger.send data, severity
     start = (monitor) ->
         logger.setMessageComposer (message, severity) ->
-            return new Buffer('<' + (this.facility * 8 + severity) + '>' +
-                this.getDate() + ' ' + app.name + '[' +
-                monitor.childData.pid + ']:' + message)
+            priority = @facility * 8 + severity
+            date = @getDate()
+            name = app.name
+            pid = monitor.childData.pid
+            return new Buffer "<#{priority}>#{date} #{name}[#{pid}]:#{message}"
         monitor.on 'stdout', sendLog
         monitor.on 'stderr', sendLog
     close = (monitor) ->

--- a/tests/config_test.coffee
+++ b/tests/config_test.coffee
@@ -49,7 +49,7 @@ describe "Configuration", ->
                     tab = data.toString().split('\n')
                     for proc in tab
                         if proc.indexOf('cozy-proxy') isnt -1
-                            proc.indexOf('localhost:9104').should.not.equal -1
+                            proc.should.contain 'localhost:9104'
 
                 lsof.on 'close', (code) ->
                     done()
@@ -85,7 +85,7 @@ describe "Configuration", ->
                     tab = data.toString().split('\n')
                     for proc in tab
                         if proc.indexOf('cozy-proxy') isnt -1
-                            proc.indexOf('*:9104').should.not.equal -1
+                            proc.should.contain '*:9104'
                 lsof.on 'close', (code) ->
                     done()
 
@@ -113,6 +113,7 @@ describe "Configuration", ->
                     scripts:
                         start: "server.coffee"
                 client.post 'apps/data-system/install', "start":app, (err, res, body) =>
+                    console.log err if err
                     @res = res
                     @port = body.drone.port
                     dsPort = @port
@@ -144,6 +145,7 @@ describe "Configuration", ->
             it "And data-system should be started", (done) ->
                 @timeout 500000
                 client.get 'drones/running', (err, res, body) =>
+                    console.log err if err
                     isRunning  = 'data-system' in Object.keys(body.app)
                     isRunning.should.equal true
                     done()

--- a/tests/static_app_test.coffee
+++ b/tests/static_app_test.coffee
@@ -77,7 +77,6 @@ describe "Install static app", ->
                     type: "static"
                 client.post 'apps/front/install', "start":app, (err, res, body) =>
                     @res = res
-                    console.log body.drone
                     @type = body.drone.type
                     dsPort = @port
                     done()


### PR DESCRIPTION
Cozy-controller can send logs from applications to files (the old behaviour) or, when using the USE_SYSLOG env variable, send logs to syslog.

To test it with cozy-dev, it is required to add these lines to `/etc/rsyslog.conf`: 

```
$ModLoad imudp
$UDPServerAddress 127.0.0.1
$UDPServerRun 514
$EscapeControlCharactersOnReceive off
```

and in `/etc/rsyslog.d/50-default.conf`, uncomment this line:

```
user.*                          -/var/log/user.log
```

and restart rsyslog with `service rsyslog restart`.

Then, you can add `USE_SYSLOG=true` to cozy-controller by editing `/etc/supervisor/conf.d/cozy-controller.conf`:

```
[program:cozy-controller]
autorestart=true
command=cozy-controller
environment=HOST="0.0.0.0", NODE_ENV="development", USE_SYSLOG="true"
redirect_stderr=true
user=root
```

And run `service supervisor restart`. You should have some logs in `/var/log/user.log`.
