### PR TITLE
Add commands.coffee proxying for npm install

### DIFF
--- a/server/lib/app.coffee
+++ b/server/lib/app.coffee
@@ -24,7 +24,8 @@ class exports.App
                     name: @app.package
                     version: 'latest'
 
-            @app.dir = path.join binDir, @app.name, 'node_modules', @app.package.name
+            dir = path.join binDir, @app.name, 'node_modules', @app.package.name
+            @app.dir ?= dir
             @app.fullnpmname = @app.package.name
             if @app.package.version
                 @app.fullnpmname += "@#{@app.package.version}"

--- a/server/lib/controller.coffee
+++ b/server/lib/controller.coffee
@@ -202,9 +202,14 @@ module.exports.removeRunningApp = (name) ->
 module.exports.install = (connection, manifest, callback) ->
     app = new App(manifest).app
     # Check if app exists
-    if drones[app.name]? or fs.existsSync(app.dir)
+    if drones[app.name]?
         log.info "#{app.name}:already installed"
         log.info "#{app.name}:start application"
+        startApp drones[app.name], callback
+
+    else if fs.existsSync(app.dir)
+        log.info "#{app.name}:already installed"
+        log.info "#{app.name}:start application from dir"
         # Start application
         startApp app, callback
     else

--- a/server/lib/npm_installer.coffee
+++ b/server/lib/npm_installer.coffee
@@ -19,14 +19,11 @@ BASE_PACKAGE_JSON = """
     }
 """
 
+# Generate a file which proxy its args to trueCommmandsFile
 COMMANDS_PROXY = (trueCommmandsFile) -> """
     {spawn} = require 'child_process'
     {dirname} = require 'path'
-    {readDirSync} = require 'fs'
-
-    trueCommmandsFile = "#{trueCommmandsFile}"
-
-    args = [trueCommmandsFile].concat process.argv[2..]
+    args = ["#{trueCommmandsFile}"].concat process.argv[2..]
     spawn 'coffee', args,
          stdio: 'inherit'
          cwd: dirname trueCommmandsFile
@@ -48,7 +45,17 @@ createAppFolder = (app, callback) ->
                     Failed to changeOwner #{dirPath} : #{err.message}
                 """
                 callback null, dirPath
-
+###
+HACK
+A lot of our infra code depends on the /usr/local/cozy/apps/home/commands.coffee
+file. This function create a commands.cofee file at the expected location
+which proxies its calls to the actual commands.coffee in
+/usr/local/cozy/apps/home/node_modules/cozy-home/commands.coffee.
+@TODO
+- Move all of the commands.coffee commands to the cozy_management
+- Use the cozy_management in infra scripts
+- Remove this function
+###
 patchCommandsCoffe = (app, callback) ->
     pname = app.package?.name or app.package
     dirPath = path.join config('dir_app_bin'), app.name

--- a/server/lib/npm_installer.coffee
+++ b/server/lib/npm_installer.coffee
@@ -20,7 +20,7 @@ BASE_PACKAGE_JSON = """
 """
 
 # Generate a file which proxy its args to trueCommmandsFile
-COMMANDS_PROXY = (trueCommmandsFile) -> """
+makeCommandsProxy = (trueCommmandsFile) -> """
     {spawn} = require 'child_process'
     {dirname} = require 'path'
     args = ["#{trueCommmandsFile}"].concat process.argv[2..]
@@ -61,7 +61,7 @@ patchCommandsCoffe = (app, callback) ->
     dirPath = path.join config('dir_app_bin'), app.name
     expectedPath = path.join dirPath, 'commands.coffee'
     truePath = path.resolve dirPath, 'node_modules', pname, 'commands.coffee'
-    fs.writeFile expectedPath, COMMANDS_PROXY(truePath), 'utf8', (err) ->
+    fs.writeFile expectedPath, makeCommandsProxy(truePath), 'utf8', (err) ->
         return callback err if err
         directory.changeOwner app.user, expectedPath, (err) ->
             return callback err if err


### PR DESCRIPTION
# This is pretty hackish
A lot of our infra code depends on the `/usr/local/cozy/apps/home/commands.coffee`
file. This function create a commands.cofee file at the expected location
which proxies its calls to the actual commands.coffee in
`/usr/local/cozy/apps/home/node_modules/cozy-home/commands.coffee`.

# in the future we want to :
- Move all of the commands.coffee commands to the cozy_management
- Use the cozy_management in infra scripts
- Revert this PR.