### PR TITLE
Improve POSIX compatibility, add compatibility with Busybox

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -128,7 +128,8 @@ task 'build', 'Build CoffeeScript to Javascript', ->
     logger.options.prefix = 'cake:build'
     logger.info "Start compilation..."
     command = "coffee -cb --output build/server server && " + \
-              "coffee -cb --output build/ server.coffee"
+              "coffee -cb --output build/ server.coffee && " + \
+              "cp server/lib/adduser.sh build/server/lib/adduser.sh"
     exec command, (err, stdout, stderr) ->
         if err
             logger.error "An error has occurred while compiling:\n" + err

--- a/server/lib/adduser.sh
+++ b/server/lib/adduser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # $USER
@@ -12,14 +12,14 @@ fi
 
 id $USER
 EXISTS=$?
-if [ $EXISTS == 0 ]; then
+if [ $EXISTS = 0 ]; then
    exit 0
 fi
 
 if command -v useradd; then
    useradd -d $HOME -m $USER
    RESULT=$?
-   if [ $RESULT == 9 ]; then
+   if [ $RESULT = 9 ]; then
      exit 0
    fi
    exit $RESULT

--- a/server/lib/adduser.sh
+++ b/server/lib/adduser.sh
@@ -27,7 +27,11 @@ elif command -v pw; then
    pw add group $USER
    pw add user $USER -g $USER -d /home/$USER -m -s /usr/local/bin/bash
 elif command -v adduser; then
-   adduser --home $HOME --gecos $USER,na,na,na $USER
+   if adduser --help 2>&1 | grep -q "BusyBox"; then
+     adduser -D -h $HOME -g $USER,na,na,na $USER
+   else
+     adduser --home $HOME --gecos $USER,na,na,na $USER
+   fi
 elif command -v dscl; then
    # Find out the next available user ID
    MAXID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -ug | tail -1)

--- a/server/lib/directory.coffee
+++ b/server/lib/directory.coffee
@@ -9,7 +9,7 @@ config = require('./conf').get
     Change owner for folder path
 ###
 module.exports.changeOwner = (user, path, callback) ->
-    child = spawn 'chown', ['--preserve-root', '-R', "#{user}:#{user}", path]
+    child = spawn 'chown', ['-R', "#{user}:#{user}", path]
     child.on 'exit', (code) ->
         if code isnt 0
             callback new Error('Unable to change permissions')

--- a/server/lib/user.coffee
+++ b/server/lib/user.coffee
@@ -17,7 +17,7 @@ module.exports.create = (app, callback) ->
     env.PATH = process.env.PATH
 
     script = path.join(__dirname, '..', 'lib', 'adduser.sh')
-    child = spawn 'bash', [script], env: env
+    child = spawn 'sh', [script], env: env
     child.on 'exit', (code) ->
         if code is 0
             callback()


### PR DESCRIPTION
This removes the unneeded dependency on bash and removes the dependency on GNU coreutils because of a non-POSIX option.  Then it adds supports for busybox's `adduser` applet.

This improves compatibility with POSIX systems not based on GNU, which is often the case in embedded systems where light alternatives like Busybox are preferred.